### PR TITLE
Add docker and vagrant configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.2.2
+RUN apt-get update -qq && apt-get install -y build-essential nodejs npm nodejs-legacy postgresql-client vim
+RUN npm install -g phantomjs
+
+RUN mkdir /bookme
+
+WORKDIR /tmp
+COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
+RUN bundle install
+
+ADD . /bookme
+WORKDIR /bookme
+EXPOSE 3000
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,77 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "hashicorp/precise64"
+
+  # Configurate the virtual machine to use 2GB of RAM
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+  end
+
+  # Forward the Rails server default port to the host
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IPrbenv rehashrake db:create.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,16 +1,42 @@
 default: &default
   adapter: postgresql
+  encoding: sql_ascii
+  username: postgres
   pool: 5
   timeout: 5000
+
+#development:
+#  <<: *default
+#  database: api_development
+
+#test:
+#  <<: *default
+#  database: api_test
+
+#production:
+#  <<: *default
+#  database: api_production
 
 development:
   <<: *default
   database: api_development
+  host: <%= ENV['DB_PORT_5432_TCP_ADDR'] %>
+  port: <%= ENV['DB_PORT_5432_TCP_PORT'] %>
 
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: api_test
+  host: <%= ENV['DB_PORT_5432_TCP_ADDR'] %>
+  port: <%= ENV['DB_PORT_5432_TCP_PORT'] %>
 
 production:
   <<: *default
   database: api_production
+  host: <%= ENV['DB_PORT_5432_TCP_ADDR'] %>
+  port: <%= ENV['DB_PORT_5432_TCP_PORT'] %>
+
+
+


### PR DESCRIPTION
# Docker 

**Build BookMe image**

- docker build -t bookme-image . 

**Pull database image**

`docker pull training/postgres`

**Run database container**

`docker run -d --name bookme-database training/postgres`

**Test connection**

`docker run -i -t --name bookme-app --link bookme-database:db bookme-image rake db:create db:migrate`

`docker rm bookme-app`

**Link container**

`docker run -d -p 80:3000 --name book-me-app --link bookme-database:db bookme-image`

**Run http://api.localhost:80/v1/services**

# Vagrant

**vagrant - bookme installation**

**Install git**

`sudo apt-get install git`                  

**Prerequisites rvben**

`sudo apt-get update`
`sudo apt-get install autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm3 libgdbm-dev`

**Install rvben**

`git clone https://github.com/rbenv/rbenv.git ~/.rbenv`
`sudo apt-get install rbenv`

**From here, you should add ~/.rbenv/bin to your $PATH so that you can use rbenv's command line utility. Also adding ~/.rbenv/bin/rbenv init to your ~/.bash_profile will let you load rbenv automatically.**

`echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc`

`echo 'eval "$(rbenv init -)"' >> ~/.bashrc`

**In order to use the rbenv install command, which simplifies the installation process for new versions of Ruby, you should install ruby-build, which we will install as a plugin for rbenv through git**

`git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build`

**Install Ruby**

`rbenv install -l ` //see all versions

`rbenv install 2.3.0`
`rbenv global 2.3.0`

**Install Rails**

`gem install bundler`
`gem install rails -v 5.0.0.1`

**rbenv works by creating a directory of shims, which point to the files used by the Ruby version that's currently enabled. Through the rehash sub-command, rbenv maintains shims in that directory to match every Ruby command across every installed version of Ruby on your server. Whenever you install a new version of Ruby or a gem that provides commands, you should run**

`rbenv rehash`

**clone repo**

`git clone https://github.com/KarenVentura/BookMe-.git`

**Install dependencies hidden**

`sudo apt-get install libpq-dev`
`bundle install`
`overcommit --install`
`sudo apt-get install postgresql`

`rake db:create`
`rake db:migrate`
`rake db:seed`